### PR TITLE
Fixed 'not a function' issue with mathjs.eval

### DIFF
--- a/src/calculator.coffee
+++ b/src/calculator.coffee
@@ -19,7 +19,7 @@ mathjs = require("mathjs")
 module.exports = (robot) ->
   robot.respond /(calc|calculate|calculator|convert|math|maths)( me)? (.*)/i, (msg) ->
     try
-      result = mathjs.eval msg.match[3]
+      result = mathjs.evaluate msg.match[3]
       msg.send "#{result}"
     catch error
       msg.send error.message || 'Could not compute.'


### PR DESCRIPTION
All calculations currently return `mathjs.eval is not a function`. 

The calculator works again after changing it to `mathjs.evaluate`